### PR TITLE
Enable Volume Control

### DIFF
--- a/Android/app/src/main/java/com/soul/neurokaraoke/service/MediaPlaybackService.kt
+++ b/Android/app/src/main/java/com/soul/neurokaraoke/service/MediaPlaybackService.kt
@@ -65,6 +65,7 @@ class MediaPlaybackService : MediaSessionService() {
                     .build(),
                 true // handleAudioFocus
             )
+            .setDeviceVolumeControlEnabled(true)
             .setHandleAudioBecomingNoisy(true)
             .build()
 


### PR DESCRIPTION
This allows devices like WearOS Watches to control the volume of the music.