### PR TITLE
Fix linux faulty behaviour when resizing the application

### DIFF
--- a/Desktop/src/main.ts
+++ b/Desktop/src/main.ts
@@ -295,7 +295,7 @@ function getOrCreateView(site: Site) {
  */
 function updateViewBounds() {
   if (!mainWindow || mainWindow.isDestroyed()) return;
-  const [width, height] = mainWindow.getContentSize();
+  const [width, height] = mainWindow.getSize();
   // Content fills entire window — titlebar overlays on top
   if (currentView) {
     currentView.setBounds({ x: 0, y: 0, width, height });


### PR DESCRIPTION
When pressing the resize window button, linux would not update the size properly. This is because getContentSize is grabbing the old size values instead of the new resized values. What it should expect is the values after resizing, not the current content value which hasn't updated yet.

Why this only happens in linux? It's more of a quirky thing related to electron in X11 and wayland.

Fixes issue #19 