### PR TITLE
Add repeat and shuffle buttons to the android notification.

### DIFF
--- a/Android/app/src/main/java/com/soul/neurokaraoke/service/AutoBrowseTree.kt
+++ b/Android/app/src/main/java/com/soul/neurokaraoke/service/AutoBrowseTree.kt
@@ -62,6 +62,7 @@ class AutoBrowseTree(private val context: Context) {
             playbackUri = RadioApi.STREAM_URL
         )
 
+        items += browsable(QUEUE_ID, "Current Queue")
         items += browsable(FAVORITES_ID, "Favorites")
         items += browsable(ALL_SONGS_ID, "All Songs")
         items += browsable(NEURO_ID, "Neuro Sings")
@@ -205,6 +206,7 @@ class AutoBrowseTree(private val context: Context) {
     companion object {
         const val ROOT_ID = "nk_root"
         const val RADIO_ID = "nk_radio"
+        const val QUEUE_ID = "nk_queue"
         const val FAVORITES_ID = "nk_favorites"
         const val ALL_SONGS_ID = "nk_all_songs"
         const val NEURO_ID = "nk_neuro"

--- a/Android/app/src/main/java/com/soul/neurokaraoke/service/MediaPlaybackService.kt
+++ b/Android/app/src/main/java/com/soul/neurokaraoke/service/MediaPlaybackService.kt
@@ -1,30 +1,31 @@
 package com.soul.neurokaraoke.service
 
+import android.app.Application
 import android.app.PendingIntent
 import android.content.Intent
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
+import androidx.media3.common.ForwardingPlayer
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
+import androidx.media3.common.Timeline
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.session.CacheBitmapLoader
+import androidx.media3.session.CommandButton
 import androidx.media3.session.LibraryResult
 import androidx.media3.session.MediaLibraryService
 import androidx.media3.session.MediaSession
 import androidx.media3.session.SessionCommand
 import androidx.media3.session.SessionResult
+import com.google.common.collect.ImmutableList
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
-import android.content.Context
-import com.soul.neurokaraoke.MainActivity
 import com.soul.neurokaraoke.audio.AudioCacheManager
-import com.soul.neurokaraoke.data.repository.LocaleManager
 import com.soul.neurokaraoke.audio.EqualizerManager
 import com.soul.neurokaraoke.data.repository.DownloadRepository
-import com.google.common.collect.ImmutableList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -32,11 +33,6 @@ import kotlinx.coroutines.guava.future
 
 @UnstableApi
 class MediaPlaybackService : MediaLibraryService() {
-
-    override fun attachBaseContext(newBase: Context) {
-        super.attachBaseContext(LocaleManager.wrapContext(newBase))
-    }
-
     private var librarySession: MediaLibrarySession? = null
     private var player: ExoPlayer? = null
     private var playerListener: Player.Listener? = null
@@ -74,27 +70,58 @@ class MediaPlaybackService : MediaLibraryService() {
             .setHandleAudioBecomingNoisy(true)
             .build()
 
+        // Load and apply saved playback settings (shuffle/repeat)
+        val prefs = getSharedPreferences("playback_state", MODE_PRIVATE)
+        player?.shuffleModeEnabled = prefs.getBoolean("shuffle_enabled", false)
+        val repeatModeName = prefs.getString("repeat_mode", "OFF")
+        player?.repeatMode = when (repeatModeName) {
+            "ONE" -> Player.REPEAT_MODE_ONE
+            "ALL" -> Player.REPEAT_MODE_ALL
+            else -> Player.REPEAT_MODE_OFF
+        }
+
+        val sessionActivityPendingIntent = PendingIntent.getActivity(
+            this,
+            0,
+            Intent(this, com.soul.neurokaraoke.MainActivity::class.java),
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+
         player?.let { exoPlayer ->
+            // Wrap player to ensure all commands are always reported as available.
+            // This is a "power user" approach to force system UIs to enable all controls.
+            val forwardingPlayer = object : ForwardingPlayer(exoPlayer) {
+                override fun getAvailableCommands(): Player.Commands {
+                    return Player.Commands.Builder()
+                        .addAllCommands()
+                        .build()
+                }
+
+                override fun isCommandAvailable(command: Int): Boolean {
+                    return true
+                }
+            }
+
             val listener = object : Player.Listener {
                 override fun onPlaybackStateChanged(playbackState: Int) {
                     if (playbackState == Player.STATE_READY) {
                         EqualizerManager.initialize(exoPlayer.audioSessionId)
                     }
                 }
+
+                override fun onTimelineChanged(timeline: Timeline, reason: Int) {
+                    librarySession?.let { s ->
+                        val count = s.player.mediaItemCount
+                        s.notifyChildrenChanged("@android:queue@", count, null)
+                        s.notifyChildrenChanged("@android:queue_all@", count, null)
+                        s.notifyChildrenChanged("nk_queue", count, null)
+                    }
+                }
             }
             playerListener = listener
             exoPlayer.addListener(listener)
-        }
 
-        val sessionActivityPendingIntent = PendingIntent.getActivity(
-            this,
-            0,
-            Intent(this, MainActivity::class.java),
-            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
-        )
-
-        player?.let { exoPlayer ->
-            librarySession = MediaLibrarySession.Builder(this, exoPlayer, LibraryCallback())
+            librarySession = MediaLibrarySession.Builder(this, forwardingPlayer, LibraryCallback())
                 .setSessionActivity(sessionActivityPendingIntent)
                 .setBitmapLoader(CacheBitmapLoader(androidx.media3.datasource.DataSourceBitmapLoader(this)))
                 .build()
@@ -105,25 +132,62 @@ class MediaPlaybackService : MediaLibraryService() {
         return librarySession
     }
 
+
+    private fun getCustomLayout(p: Player?): ImmutableList<CommandButton> {
+        val isShuffle = p?.shuffleModeEnabled == true
+        val repeatMode = p?.repeatMode ?: Player.REPEAT_MODE_OFF
+
+        val shuffleIcon = if (isShuffle)
+            androidx.media3.ui.R.drawable.exo_icon_shuffle_on
+        else
+            androidx.media3.ui.R.drawable.exo_icon_shuffle_off
+
+        val repeatIcon = when (repeatMode) {
+            Player.REPEAT_MODE_ONE -> androidx.media3.ui.R.drawable.exo_icon_repeat_one
+            Player.REPEAT_MODE_ALL -> androidx.media3.ui.R.drawable.exo_icon_repeat_all
+            else -> androidx.media3.ui.R.drawable.exo_icon_repeat_off
+        }
+
+        val shuffleButton = CommandButton.Builder()
+            .setSessionCommand(SessionCommand("ACTION_SHUFFLE", android.os.Bundle.EMPTY))
+            .setIconResId(shuffleIcon)
+            .setDisplayName("Shuffle")
+            .build()
+        val repeatButton = CommandButton.Builder()
+            .setSessionCommand(SessionCommand("ACTION_REPEAT", android.os.Bundle.EMPTY))
+            .setIconResId(repeatIcon)
+            .setDisplayName("Repeat")
+            .build()
+
+        return ImmutableList.of(shuffleButton, repeatButton)
+    }
+
     private inner class LibraryCallback : MediaLibrarySession.Callback {
 
         override fun onConnect(
             session: MediaSession,
             controller: MediaSession.ControllerInfo
         ): MediaSession.ConnectionResult {
-            val sessionCommands = MediaSession.ConnectionResult.DEFAULT_SESSION_COMMANDS.buildUpon().build()
-            val playerCommands = MediaSession.ConnectionResult.DEFAULT_PLAYER_COMMANDS.buildUpon()
-                .add(Player.COMMAND_SEEK_TO_NEXT)
-                .add(Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM)
-                .add(Player.COMMAND_SEEK_TO_PREVIOUS)
-                .add(Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM)
-                .add(Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM)
-                .add(Player.COMMAND_PLAY_PAUSE)
-                .add(Player.COMMAND_STOP)
+            val shuffleCommand = SessionCommand("ACTION_SHUFFLE", android.os.Bundle.EMPTY)
+            val repeatCommand = SessionCommand("ACTION_REPEAT", android.os.Bundle.EMPTY)
+            val sessionCommands = MediaSession.ConnectionResult.DEFAULT_SESSION_COMMANDS.buildUpon()
+                .add(shuffleCommand)
+                .add(repeatCommand)
+                .add(SessionCommand(SessionCommand.COMMAND_CODE_LIBRARY_GET_LIBRARY_ROOT))
+                .add(SessionCommand(SessionCommand.COMMAND_CODE_LIBRARY_GET_CHILDREN))
+                .add(SessionCommand(SessionCommand.COMMAND_CODE_LIBRARY_GET_ITEM))
+                .add(SessionCommand(SessionCommand.COMMAND_CODE_LIBRARY_SEARCH))
+                .add(SessionCommand(SessionCommand.COMMAND_CODE_LIBRARY_GET_SEARCH_RESULT))
                 .build()
+
+            val playerCommands = Player.Commands.Builder()
+                .addAllCommands()
+                .build()
+
             return MediaSession.ConnectionResult.AcceptedResultBuilder(session)
                 .setAvailableSessionCommands(sessionCommands)
                 .setAvailablePlayerCommands(playerCommands)
+                .setCustomLayout(getCustomLayout(session.player))
                 .build()
         }
 
@@ -133,6 +197,49 @@ class MediaPlaybackService : MediaLibraryService() {
             customCommand: SessionCommand,
             args: android.os.Bundle
         ): ListenableFuture<SessionResult> {
+            val action = customCommand.customAction
+            if (action == "ACTION_SHUFFLE") {
+                session.player.shuffleModeEnabled = !session.player.shuffleModeEnabled
+                
+                // Persist change so it survives service/app restarts and stays in sync with ViewModel
+                val prefs = getSharedPreferences("playback_state", MODE_PRIVATE)
+                prefs.edit().putBoolean("shuffle_enabled", session.player.shuffleModeEnabled).apply()
+
+                // Force a full session refresh by simulating the onTimelineChanged event
+                librarySession?.let { s ->
+                    s.notifyChildrenChanged("@android:queue@", s.player.mediaItemCount, null)
+                    s.notifyChildrenChanged("@android:queue_all@", s.player.mediaItemCount, null)
+                    s.notifyChildrenChanged("nk_queue", s.player.mediaItemCount, null)
+                    s.notifyChildrenChanged("nk_root", 0, null)
+                }
+                librarySession?.setCustomLayout(getCustomLayout(session.player))
+                return Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
+            } else if (action == "ACTION_REPEAT") {
+                session.player.repeatMode = when (session.player.repeatMode) {
+                    Player.REPEAT_MODE_OFF -> Player.REPEAT_MODE_ALL
+                    Player.REPEAT_MODE_ALL -> Player.REPEAT_MODE_ONE
+                    else -> Player.REPEAT_MODE_OFF
+                }
+
+                // Persist change so it survives service/app restarts and stays in sync with ViewModel
+                val repeatModeName = when (session.player.repeatMode) {
+                    Player.REPEAT_MODE_ONE -> "ONE"
+                    Player.REPEAT_MODE_ALL -> "ALL"
+                    else -> "OFF"
+                }
+                val prefs = getSharedPreferences("playback_state", MODE_PRIVATE)
+                prefs.edit().putString("repeat_mode", repeatModeName).apply()
+
+                // Notify that the queue "changed" (status icons/order might need refresh in some UIs)
+                librarySession?.let { s ->
+                    s.notifyChildrenChanged("@android:queue@", s.player.mediaItemCount, null)
+                    s.notifyChildrenChanged("@android:queue_all@", s.player.mediaItemCount, null)
+                    s.notifyChildrenChanged("nk_queue", s.player.mediaItemCount, null)
+                }
+
+                librarySession?.setCustomLayout(getCustomLayout(session.player))
+                return Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
+            }
             return Futures.immediateFuture(SessionResult(SessionResult.RESULT_ERROR_NOT_SUPPORTED))
         }
 
@@ -149,6 +256,16 @@ class MediaPlaybackService : MediaLibraryService() {
             browser: MediaSession.ControllerInfo,
             mediaId: String
         ): ListenableFuture<LibraryResult<MediaItem>> = serviceScope.future {
+            // First, try to find the item in the current player's timeline
+            val player = session.player
+            for (i in 0 until player.mediaItemCount) {
+                val item = player.getMediaItemAt(i)
+                if (item.mediaId == mediaId) {
+                    return@future LibraryResult.ofItem(item, null)
+                }
+            }
+
+            // Fallback to the browse tree
             val item = browseTree.item(mediaId)
             if (item != null) LibraryResult.ofItem(item, null)
             else LibraryResult.ofError(LibraryResult.RESULT_ERROR_BAD_VALUE)
@@ -162,6 +279,42 @@ class MediaPlaybackService : MediaLibraryService() {
             pageSize: Int,
             params: LibraryParams?
         ): ListenableFuture<LibraryResult<ImmutableList<MediaItem>>> = serviceScope.future {
+            // Handle special system IDs for the playback queue
+            if (parentId == "@android:queue@" || parentId == "@android:queue_all@" || parentId == "nk_queue") {
+                val player = session.player
+                val items = mutableListOf<MediaItem>()
+                
+                if (player.shuffleModeEnabled && parentId != "@android:queue_all@") {
+                    // Return items in shuffled order as they will be played
+                    val timeline = player.currentTimeline
+                    var nextIdx = player.currentMediaItemIndex
+                    val seen = mutableSetOf<Int>()
+                    
+                    while (nextIdx != C.INDEX_UNSET && !seen.contains(nextIdx) && items.size < player.mediaItemCount) {
+                        items.add(player.getMediaItemAt(nextIdx))
+                        seen.add(nextIdx)
+                        nextIdx = timeline.getNextWindowIndex(nextIdx, Player.REPEAT_MODE_OFF, true)
+                    }
+                    
+                    // If we missed some items (e.g. they were before current in shuffle order),
+                    // fill them in to ensure a full list.
+                    if (items.size < player.mediaItemCount) {
+                        for (i in 0 until player.mediaItemCount) {
+                            if (!seen.contains(i)) {
+                                items.add(player.getMediaItemAt(i))
+                                seen.add(i)
+                            }
+                        }
+                    }
+                } else {
+                    // Standard order
+                    for (i in 0 until player.mediaItemCount) {
+                        items.add(player.getMediaItemAt(i))
+                    }
+                }
+                return@future LibraryResult.ofItemList(ImmutableList.copyOf(items), params)
+            }
+
             val all = browseTree.children(parentId)
             val from = (page * pageSize).coerceAtMost(all.size)
             val to = (from + pageSize).coerceAtMost(all.size)

--- a/Android/app/src/main/java/com/soul/neurokaraoke/service/MediaPlaybackService.kt
+++ b/Android/app/src/main/java/com/soul/neurokaraoke/service/MediaPlaybackService.kt
@@ -92,12 +92,34 @@ class MediaPlaybackService : MediaLibraryService() {
             // This is a "power user" approach to force system UIs to enable all controls.
             val forwardingPlayer = object : ForwardingPlayer(exoPlayer) {
                 override fun getAvailableCommands(): Player.Commands {
-                    return Player.Commands.Builder()
-                        .addAllCommands()
-                        .build()
+                    val mediaId = wrappedPlayer.currentMediaItem?.mediaId
+                    val isRadio = mediaId == "radio_live" || mediaId == "nk_radio"
+
+                    val commands = Player.Commands.Builder().addAllCommands()
+                    if (isRadio) {
+                        commands.remove(Player.COMMAND_SEEK_TO_NEXT)
+                        commands.remove(Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM)
+                        commands.remove(Player.COMMAND_SEEK_TO_PREVIOUS)
+                        commands.remove(Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM)
+                        commands.remove(Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM)
+                    }
+                    return commands.build()
                 }
 
                 override fun isCommandAvailable(command: Int): Boolean {
+                    val mediaId = wrappedPlayer.currentMediaItem?.mediaId
+                    val isRadio = mediaId == "radio_live" || mediaId == "nk_radio"
+
+                    if (isRadio) {
+                        return when (command) {
+                            Player.COMMAND_SEEK_TO_NEXT,
+                            Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM,
+                            Player.COMMAND_SEEK_TO_PREVIOUS,
+                            Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM,
+                            Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM -> false
+                            else -> true
+                        }
+                    }
                     return true
                 }
             }
@@ -117,6 +139,12 @@ class MediaPlaybackService : MediaLibraryService() {
                         s.notifyChildrenChanged("nk_queue", count, null)
                     }
                 }
+
+                override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
+                    librarySession?.let { s ->
+                        s.setCustomLayout(getCustomLayout(s.player))
+                    }
+                }
             }
             playerListener = listener
             exoPlayer.addListener(listener)
@@ -134,6 +162,11 @@ class MediaPlaybackService : MediaLibraryService() {
 
 
     private fun getCustomLayout(p: Player?): ImmutableList<CommandButton> {
+        val mediaId = p?.currentMediaItem?.mediaId
+        if (mediaId == "radio_live" || mediaId == "nk_radio") {
+            return ImmutableList.of()
+        }
+
         val isShuffle = p?.shuffleModeEnabled == true
         val repeatMode = p?.repeatMode ?: Player.REPEAT_MODE_OFF
 

--- a/Android/app/src/main/java/com/soul/neurokaraoke/ui/screens/player/PlayerScreen.kt
+++ b/Android/app/src/main/java/com/soul/neurokaraoke/ui/screens/player/PlayerScreen.kt
@@ -478,7 +478,10 @@ fun PlayerScreen(
                 Icon(
                     imageVector = Icons.Default.Shuffle,
                     contentDescription = stringResource(R.string.player_content_description_shuffle),
-                    tint = if (isShuffleEnabled) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
+                    tint = if (isShuffleEnabled)
+                        MaterialTheme.colorScheme.primary
+                    else
+                        MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
 

--- a/Android/app/src/main/java/com/soul/neurokaraoke/viewmodel/PlayerViewModel.kt
+++ b/Android/app/src/main/java/com/soul/neurokaraoke/viewmodel/PlayerViewModel.kt
@@ -5,9 +5,11 @@ import android.content.ComponentName
 import android.content.Context
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
+import androidx.media3.common.Timeline
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
 import com.soul.neurokaraoke.data.PlaylistCatalog
@@ -333,19 +335,19 @@ class PlayerViewModel(
                             progress = 0f,
                             currentPosition = 0L
                         )
+                        // Refresh queue order whenever we transition to a new song, 
+                        // especially important for keeping the "Up Next" accurate.
+                        refreshQueueFromPlayer()
                         savePlaybackState()
                     }
                 }
             }
 
             override fun onShuffleModeEnabledChanged(shuffleModeEnabled: Boolean) {
-                val savedShuffle = _uiState.value.isShuffleEnabled
-                if (shuffleModeEnabled != savedShuffle) {
-                    // Player's shuffle was reset (e.g. service restart) — re-apply saved mode
-                    mediaController?.shuffleModeEnabled = savedShuffle
-                    return
-                }
                 _uiState.value = _uiState.value.copy(isShuffleEnabled = shuffleModeEnabled)
+                refreshQueueFromPlayer()
+                // Persist change so it survives service/app restarts
+                prefs.edit().putBoolean("shuffle_enabled", shuffleModeEnabled).apply()
             }
 
             override fun onRepeatModeChanged(repeatMode: Int) {
@@ -354,17 +356,9 @@ class PlayerViewModel(
                     Player.REPEAT_MODE_ALL -> RepeatMode.ALL
                     else -> RepeatMode.OFF
                 }
-                val savedMode = _uiState.value.repeatMode
-                if (mode != savedMode) {
-                    // Player's repeat mode was reset (e.g. service restart) — re-apply saved mode
-                    mediaController?.repeatMode = when (savedMode) {
-                        RepeatMode.OFF -> Player.REPEAT_MODE_OFF
-                        RepeatMode.ONE -> Player.REPEAT_MODE_ONE
-                        RepeatMode.ALL -> Player.REPEAT_MODE_ALL
-                    }
-                    return
-                }
                 _uiState.value = _uiState.value.copy(repeatMode = mode)
+                // Persist change so it survives service/app restarts
+                prefs.edit().putString("repeat_mode", mode.name).apply()
             }
         }
         playerListener = listener
@@ -378,6 +372,67 @@ class PlayerViewModel(
             RepeatMode.ALL -> Player.REPEAT_MODE_ALL
         }
         mediaController?.shuffleModeEnabled = _uiState.value.isShuffleEnabled
+
+        // Sync current song and queue if player is empty (e.g. after restoration or service restart)
+        val currentSong = _uiState.value.currentSong
+        if (currentSong != null && mediaController?.mediaItemCount == 0) {
+            playSong(currentSong, _uiState.value.currentPosition)
+        } else {
+            // Player is not empty, refresh our local queue state to match the player's true order
+            refreshQueueFromPlayer()
+        }
+    }
+
+    /**
+     * Reconstructs the queue from the player's current timeline and shuffle order.
+     * This ensures the "Up Next" list in the UI accurately reflects what will play next.
+     */
+    private fun refreshQueueFromPlayer() {
+        val controller = mediaController ?: return
+        val count = controller.mediaItemCount
+        if (count == 0) return
+
+        val currentState = _uiState.value
+        val newQueue = mutableListOf<Song>()
+        val currentIdx = controller.currentMediaItemIndex
+        if (currentIdx == C.INDEX_UNSET) return
+
+        var nextIdx = currentIdx
+        val seen = mutableSetOf<Int>()
+
+        // Follow the "next" links in the player's timeline (respects shuffle mode)
+        while (nextIdx != C.INDEX_UNSET && !seen.contains(nextIdx) && newQueue.size < count) {
+            val mediaItem = controller.getMediaItemAt(nextIdx)
+            val mediaId = mediaItem.mediaId
+            
+            // Find the song metadata in our catalogs
+            val song = currentState.allSongs.find { it.id == mediaId }
+                ?: currentState.songs.find { it.id == mediaId }
+                ?: currentState.queue.find { it.id == mediaId } // Fallback to current queue metadata
+                ?: Song(
+                    id = mediaId,
+                    title = mediaItem.mediaMetadata.title?.toString() ?: "Unknown",
+                    artist = mediaItem.mediaMetadata.artist?.toString() ?: "",
+                    coverUrl = mediaItem.mediaMetadata.artworkUri?.toString() ?: "",
+                    audioUrl = mediaItem.localConfiguration?.uri?.toString() ?: "",
+                    singer = Singer.NEURO
+                )
+            
+            newQueue.add(song)
+            seen.add(nextIdx)
+            
+            // Ask the timeline for the next index, respecting the current shuffle state
+            nextIdx = controller.currentTimeline.getNextWindowIndex(
+                nextIdx, 
+                Player.REPEAT_MODE_OFF, 
+                controller.shuffleModeEnabled
+            )
+        }
+        
+        // If we didn't find the current song in the loop for some reason, don't wipe the queue
+        if (newQueue.isNotEmpty()) {
+            _uiState.value = _uiState.value.copy(queue = newQueue)
+        }
     }
 
     private var lastPeriodicSaveTime = 0L
@@ -532,14 +587,42 @@ class PlayerViewModel(
 
             repository.getPlaylistSongs(playlistId).fold(
                 onSuccess = { songs ->
-                    _uiState.value = _uiState.value.copy(
+                    val currentState = _uiState.value
+                    
+                    // Decide whether to update the actual playback queue.
+                    // We update if the queue is empty, or if it's a single-item queue (likely from restoration)
+                    // and this playlist contains that song, so we can "expand" the queue.
+                    val isRestoredQueue = currentState.queue.size <= 1 && !currentState.isCustomQueue
+                    val isCurrentSongInThisPlaylist = songs.any { it.id == currentState.currentSong?.id }
+                    val shouldUpdateQueue = currentState.queue.isEmpty() || (isRestoredQueue && isCurrentSongInThisPlaylist)
+
+                    var newQueue = if (shouldUpdateQueue) songs else currentState.queue
+                    
+                    // Apply shuffle if we are expanding/updating the queue and shuffle is on
+                    if (shouldUpdateQueue && currentState.isShuffleEnabled && newQueue.size > 1) {
+                        val currentSong = currentState.currentSong ?: newQueue.first()
+                        val others = newQueue.filter { it.id != currentSong.id }.shuffled()
+                        newQueue = listOf(currentSong) + others
+                    }
+
+                    _uiState.value = currentState.copy(
                         songs = songs,
-                        queue = songs,
+                        queue = newQueue,
                         isLoading = false,
                         currentPlaylistId = playlistId,
                         currentPlaylist = playlist,
-                        currentSong = _uiState.value.currentSong ?: songs.firstOrNull()
+                        currentSong = currentState.currentSong ?: songs.firstOrNull()
                     )
+
+                    // If we expanded the queue and the player is already active, sync the new items to it
+                    if (shouldUpdateQueue) {
+                        mediaController?.let { controller ->
+                            val currentSong = _uiState.value.currentSong
+                            if (currentSong != null && controller.mediaItemCount <= 1) {
+                                playSong(currentSong, controller.currentPosition)
+                            }
+                        }
+                    }
 
                     // Update playlist metadata if missing (fallback from song data)
                     if (playlist != null && (playlist.previewCovers.isEmpty() || playlist.songCount == 0)) {
@@ -603,16 +686,22 @@ class PlayerViewModel(
         isRestoringState = false
         savePlaybackState()
 
-        val controller = mediaController ?: return
-        var queueSongs = _uiState.value.queue.ifEmpty { _uiState.value.songs }
+        // Source the queue from the current playlist, or fall back to the existing queue
+        var queueSongs = if (!_uiState.value.isCustomQueue && _uiState.value.songs.isNotEmpty()) {
+            _uiState.value.songs
+        } else {
+            _uiState.value.queue
+        }
+        if (queueSongs.isEmpty()) queueSongs = listOf(song)
+        
         var songIndex = queueSongs.indexOfFirst { it.id == song.id }
 
-        // Song not in current queue — try allSongs
+        // Song not in current list — try allSongs
         if (songIndex < 0 && _uiState.value.allSongs.isNotEmpty()) {
             queueSongs = _uiState.value.allSongs
             songIndex = queueSongs.indexOfFirst { it.id == song.id }
             if (songIndex >= 0) {
-                _uiState.value = _uiState.value.copy(queue = queueSongs, currentPlaylistId = null)
+                _uiState.value = _uiState.value.copy(currentPlaylistId = null, isCustomQueue = false)
             }
         }
 
@@ -620,11 +709,39 @@ class PlayerViewModel(
         if (songIndex < 0) {
             queueSongs = listOf(song)
             songIndex = 0
-            _uiState.value = _uiState.value.copy(queue = queueSongs)
+        }
+
+        // Update the UI state with the base queue. 
+        // If shuffle is ON, refreshQueueFromPlayer() will soon override this with the shuffled order.
+        _uiState.value = _uiState.value.copy(queue = queueSongs)
+
+        val controller = mediaController ?: return
+
+        // Sync shuffle mode to the controller before setting items
+        controller.shuffleModeEnabled = _uiState.value.isShuffleEnabled
+
+        // Optimization: If the controller already has the correct items, just seek.
+        // In shuffle mode, we check if the ID matches at the expected index.
+        if (controller.mediaItemCount == queueSongs.size && songIndex >= 0 && songIndex < controller.mediaItemCount) {
+            val currentItem = controller.getMediaItemAt(songIndex)
+            if (currentItem.mediaId == song.id) {
+                controller.seekTo(songIndex, resumePos)
+                controller.play()
+                refreshQueueFromPlayer()
+                return
+            }
         }
 
         // Build media items for the queue
         val mediaItems = queueSongs.map { s ->
+            val extras = android.os.Bundle()
+            extras.putBoolean("androidx.media3.session.MediaSession.EXTRA_KEY_QUEUE_SUPPORTED", true)
+            extras.putInt("androidx.media3.session.MediaSession.EXTRA_KEY_QUEUE_SUPPORTED", 1)
+            extras.putBoolean("androidx.media.utils.Extras.SLOT_RESERVATION_QUEUE", true)
+            extras.putBoolean("androidx.media.PlaybackStateCompat.Extras.COMMAND_GET_TIMELINE", true)
+            extras.putBoolean("android.media.session.extra.QUEUE_SUPPORTED", true)
+            extras.putInt("android.media.session.extra.QUEUE_SUPPORTED", 1)
+
             MediaItem.Builder()
                 .setUri(s.audioUrl)
                 .setMediaId(s.id)
@@ -637,6 +754,7 @@ class PlayerViewModel(
                         .setMediaType(MediaMetadata.MEDIA_TYPE_MUSIC)
                         .setIsBrowsable(false)
                         .setIsPlayable(true)
+                        .setExtras(extras)
                         .build()
                 )
                 .build()
@@ -649,12 +767,18 @@ class PlayerViewModel(
     }
 
     /**
-     * Play song by ID from current playlist
+     * Play song by ID, searching in queue, current playlist, and all songs
      */
     fun playSongById(songId: String) {
-        val song = _uiState.value.songs.find { it.id == songId }
+        val song = _uiState.value.queue.find { it.id == songId }
+            ?: _uiState.value.songs.find { it.id == songId }
+            ?: _uiState.value.allSongs.find { it.id == songId }
+
         song?.let {
-            _uiState.value = _uiState.value.copy(isCustomQueue = false)
+            // If it's not in the current playlist but in songs, it might be a playlist play
+            if (_uiState.value.queue.none { s -> s.id == songId } && _uiState.value.songs.any { s -> s.id == songId }) {
+                _uiState.value = _uiState.value.copy(isCustomQueue = false)
+            }
             playSong(it)
         }
     }


### PR DESCRIPTION
This adds the repeat and shuffle buttons to the notification.

Known issues:
- Queue on Android Auto does not shuffle. 
- Queue on Android Wear isn't working yet. See bug [1439](https://github.com/androidx/media/issues/1439) of androidx.media.